### PR TITLE
Version bump acorn-private-class-elements@0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "test262-parser-runner": "^0.5.0"
   },
   "dependencies": {
-    "acorn-private-class-elements": "^0.1.1"
+    "acorn-private-class-elements": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint -c .eslintrc.json ."
   },
   "peerDependencies": {
-    "acorn": "^6.0.0"
+    "acorn": "^6.0.0 || ^7.0.0"
   },
   "version": "0.3.1",
   "devDependencies": {


### PR DESCRIPTION
Version bump for the `acorn-private-class-elements` dependency (as part of unlocking some `acorn@7` upgrades elsewhere).