### PR TITLE
Permit keyword in class fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(Parser) {
 
     // Parse fields
     parseClassElement(_constructorAllowsSuper) {
-      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type == tt.keyword || this.type == this.privateNameToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
+      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type.keyword || this.type == this.privateNameToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
         const branch = this._branch()
         if (branch.type == tt.bracketL) {
           let count = 0

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(Parser) {
 
     // Parse fields
     parseClassElement(_constructorAllowsSuper) {
-      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type == this.privateNameToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
+      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type == tt.keyword || this.type == this.privateNameToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
         const branch = this._branch()
         if (branch.type == tt.bracketL) {
           let count = 0

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,7 @@ describe("acorn-class-fields", function () {
     }
   }`)
   test("class A { a = this.#a; #a = 4 }")
+  test("class A { delete = 5; #delete = 5 }")
 
   testFail("class A { #a; f() { delete this.#a } }", "Private elements may not be deleted (1:20)")
   testFail("class A { #a; #a }", "Duplicate private element (1:14)")

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,8 @@ describe("acorn-class-fields", function () {
     }
   }`)
   test("class A { a = this.#a; #a = 4 }")
+  
+  test("class A { 5 = 5; #5 = 5 }")
   test("class A { delete = 5; #delete = 5 }")
 
   testFail("class A { #a; f() { delete this.#a } }", "Private elements may not be deleted (1:20)")


### PR DESCRIPTION
This updates the implementation to permit keywords in the field name, for example:

```js
class X {
  delete = 5;
}
```