### PR TITLE
Support await

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ module.exports = function(Parser) {
       if (this.eat(tt.eq)) {
         const oldInFieldValue = this._inFieldValue
         this._inFieldValue = true
-        field.value = this.parseExpression()
+        if (this.type === tt.name && this.value === 'await' && (this.inAsync || this.options.allowAwaitOutsideFunction)) {
+          field.value = this.parseAwait()
+        } else field.value = this.parseExpression()
         this._inFieldValue = oldInFieldValue
       } else field.value = null
     }

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ const Parser = acorn.Parser.extend(classFields)
 
 function test(text, expectedResult, additionalOptions) {
   it(text, function () {
-    const result = Parser.parse(text, Object.assign({ ecmaVersion: 9 }, additionalOptions))
+    const result = Parser.parse(text, Object.assign({ ecmaVersion: 9, allowAwaitOutsideFunction: true }, additionalOptions))
     if (expectedResult) {
       assert.deepStrictEqual(result.body[0], expectedResult)
     }
@@ -55,6 +55,12 @@ describe("acorn-class-fields", function () {
 
       // state
       done= false
+    }
+  `)
+
+  test(`
+    class Class {
+      value = await getValue();
     }
   `)
 


### PR DESCRIPTION
This attempts to fix https://github.com/acornjs/acorn-class-fields/issues/12.

It's a little odd that the state isn't already right to detect this without custom branches, but it does the job. Certainly not viable code for upstreaming though.