### PR TITLE
Update AST node names to match ESTree [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a plugin for [Acorn](http://marijnhaverbeke.nl/acorn/) - a tiny, fast JavaScript parser, written completely in JavaScript.
 
-It implements support for class fields as defined in the stage 3 proposal [Class field declarations for JavaScript](https://github.com/tc39/proposal-class-fields). The emitted AST follows [an ESTree proposal](https://github.com/estree/estree/pull/180).
+It implements support for class fields as defined in the stage 3 proposal [Class field declarations for JavaScript](https://github.com/tc39/proposal-class-fields). The emitted AST follows the [ESTree experimental Class Features design](https://github.com/estree/estree/blob/master/experimental/class-features.md).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(Parser) {
 
     // Parse fields
     parseClassElement(_constructorAllowsSuper) {
-      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type.keyword || this.type == this.privateNameToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
+      if (this.options.ecmaVersion >= 8 && (this.type == tt.name || this.type.keyword || this.type == this.privateIdentifierToken || this.type == tt.bracketL || this.type == tt.string || this.type == tt.num)) {
         const branch = this._branch()
         if (branch.type == tt.bracketL) {
           let count = 0
@@ -37,7 +37,7 @@ module.exports = function(Parser) {
         }
         if (isField) {
           const node = this.startNode()
-          if (this.type == this.privateNameToken) {
+          if (this.type == this.privateIdentifierToken) {
             this.parsePrivateClassElementName(node)
           } else {
             this.parsePropertyName(node)
@@ -49,7 +49,7 @@ module.exports = function(Parser) {
           this.enterScope(64 | 2 | 1) // See acorn's scopeflags.js
           this._maybeParseFieldValue(node)
           this.exitScope()
-          this.finishNode(node, "FieldDefinition")
+          this.finishNode(node, "PropertyDefinition")
           this.semicolon()
           return node
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "acorn": "^6 || ^7 || ^8"
   },
-  "version": "0.3.7",
+  "version": "1.0.0",
   "devDependencies": {
     "acorn": "^8",
     "eslint": "^7.2",
@@ -31,6 +31,6 @@
     "test262-parser-runner": "^0.5.0"
   },
   "dependencies": {
-    "acorn-private-class-elements": "^0.2.7"
+    "acorn-private-class-elements": "^1.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -143,10 +143,10 @@ describe("acorn-class-fields", function () {
           type: "ClassBody",
           end: body.end + 6,
           body: [body, newNode(body.end + 2, {
-            type: "FieldDefinition",
+            type: "PropertyDefinition",
             end: body.end + 4,
             key: newNode(body.end + 2, {
-              type: "PrivateName",
+              type: "PrivateIdentifier",
               end: body.end + 4,
               name: "y"
             }),
@@ -249,7 +249,7 @@ describe("acorn-class-fields", function () {
 
   [
     { body: "x", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 1,
       key: newNode(start, {
         type: "Identifier",
@@ -260,7 +260,7 @@ describe("acorn-class-fields", function () {
       computed: false
     }) },
     { body: "x = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 5,
       key: newNode(start, {
         type: "Identifier",
@@ -276,7 +276,7 @@ describe("acorn-class-fields", function () {
       computed: false
     }) },
     { body: "[x]", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 3,
       computed: true,
       key: newNode(start + 1, {
@@ -287,7 +287,7 @@ describe("acorn-class-fields", function () {
       value: null
     }) },
     { body: "[x] = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 7,
       computed: true,
       key: newNode(start + 1, {
@@ -303,22 +303,22 @@ describe("acorn-class-fields", function () {
       })
     }) },
     { body: "#x", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 2,
       computed: false,
       key: newNode(start, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 2,
         name: "x"
       }),
       value: null,
     }) },
     { body: "#x = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 6,
       computed: false,
       key: newNode(start, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 2,
         name: "x"
       }),
@@ -331,7 +331,7 @@ describe("acorn-class-fields", function () {
     }) },
 
     { body: "async", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 5,
       key: newNode(start, {
         type: "Identifier",
@@ -343,7 +343,7 @@ describe("acorn-class-fields", function () {
     }) },
 
     { body: "async = 5", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 9,
       key: newNode(start, {
         type: "Identifier",


### PR DESCRIPTION
FieldDefinition -> PropertyDefinition
PrivateName -> PrivateIdentifier
privateNameToken -> privateIdentifierToker

Fixes #15

This follows https://github.com/acornjs/acorn-private-class-elements/pull/16 and precedes a update to acorn-stage3.